### PR TITLE
fix import ansi in drafter.py

### DIFF
--- a/draftlog/drafter.py
+++ b/draftlog/drafter.py
@@ -1,8 +1,8 @@
 from .logdraft import LogDraft
+from . import ansi
 import draftlog
 import time
 import sys
-import ansi
 import threading
 
 # Imports the correct module according to


### PR DESCRIPTION
To prevent `ImportError: No module named 'ansi'`