### PR TITLE
Fix importerror

### DIFF
--- a/draftlog/logdraft.py
+++ b/draftlog/logdraft.py
@@ -1,4 +1,4 @@
-import ansi
+from . import ansi
 import sys
 
 """


### PR DESCRIPTION
To prevent `ImportError: No module named 'ansi'`